### PR TITLE
Change slack link in readme to invite based

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The argument to `quicktype` is a complex object with many optional properties. [
 
 ## Contributing
 
-`quicktype` is [Open Source](LICENSE) and we love contributors! In fact, we have a [list of issues](https://github.com/quicktype/quicktype/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3Ahelp-wanted) that are low-priority for us, but for which we'd happily accept contributions. Support for new target languages is also strongly desired. If you'd like to contribute, need help with anything at all, or would just like to talk things over, come [join us on Slack](https://quicktype.slack.com/).
+`quicktype` is [Open Source](LICENSE) and we love contributors! In fact, we have a [list of issues](https://github.com/quicktype/quicktype/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3Ahelp-wanted) that are low-priority for us, but for which we'd happily accept contributions. Support for new target languages is also strongly desired. If you'd like to contribute, need help with anything at all, or would just like to talk things over, come [join us on Slack](http://slack.quicktype.io/).
 
 ### Setup, Build, Run
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ async function main() {
 main();
 ```
 
-The argument to `quicktype` is a complex object with many optional properties. [Explore its definition](https://github.com/quicktype/quicktype-vscode/blob/master/src/extension.ts#L141) to understand what options are allowed.
+The argument to `quicktype` is a complex object with many optional properties. [Explore its definition](https://github.com/quicktype/quicktype/blob/master/src/quicktype-core/Run.ts#L119) to understand what options are allowed.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ async function main() {
 main();
 ```
 
-The argument to `quicktype` is a complex object with many optional properties. [Explore its definition](https://github.com/quicktype/quicktype/blob/javascript-use-examples/src/quicktype-core/Run.ts#L171) to understand what options are allowed.
+The argument to `quicktype` is a complex object with many optional properties. [Explore its definition](https://github.com/quicktype/quicktype-vscode/blob/master/src/extension.ts#L141) to understand what options are allowed.
 
 ## Contributing
 


### PR DESCRIPTION
The current link takes you to slack sign-in page, but if it is your first time (like mine) you are doomed. I had to look for a proper invite-like link on a website, so I just want to avoid others follow my struggle. 